### PR TITLE
episode name is optional

### DIFF
--- a/lib/classes/episode_link.rb
+++ b/lib/classes/episode_link.rb
@@ -19,7 +19,7 @@ class EpisodeLink < Struct.new(:href)
   end
 
   def episode_regex
-    @episode_regex ||= href.match(/(episode-)(?<episode_number>\d{3})(-)(?<episode_name>.*)/)
+    @episode_regex ||= href.match(/(episode-)(?<episode_number>\d{3})(-?)(?<episode_name>.*)/)
   end
 
   def link_obj


### PR DESCRIPTION
Episode numbers like 265,267 do not have an episode name. - after the number in such cases is optional. 