### PR TITLE
Adding Windows support and possibility to specify number of the episode to start the download 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 RubyTapas/
+lib/ca-bundle.crt
 constants.rb

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Steps
 2. Copy the `constants.rb.example` file to `constants.rb`
 3. Fill out constants.rb with your:
    - your username and password
+   - optional: use a number of the episode from which you want to start the download 
    - optional: a different directory if you don't want the default RubyTapas
    - if your encounter certificate failure, download the ca-bundrle.crt from below and
    change the CA_FILE to eg.'lib/ca-bundle.crt'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Steps
 3. Fill out constants.rb with your:
    - your username and password
    - optional: a different directory if you don't want the default RubyTapas
-
+   - if your encounter certificate failure, download the ca-bundrle.crt from below and
+   change the CA_FILE to eg.'lib/ca-bundle.crt'
 4. In a terminal run `ruby ruby-tapas-downloader`
 
 The downloader will put your episodes in this format
@@ -25,3 +26,11 @@ The downloader will put your episodes in this format
      /episode.mp4       #video episode
      /full_page.html    #page html with all links
      /page_content.hrml #page_content div from page
+````
+
+##### Windows users
+You may encounter the `ruby SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (OpenSSL::SSL::SSLError)`
+This error is due to Ruby not being able to find the certification authority 
+certificates (CA Certs) used to verify the authenticity of secured web servers. 
+The solution is to download the this [ca-bundle.crt](http://curl.haxx.se/ca/ca-bundle.crt) and 
+add it to lib/ directory.

--- a/constants.rb.example
+++ b/constants.rb.example
@@ -1,6 +1,7 @@
 USER_NAME = ''
 USER_PASSWORD = ''
 
+ALREADY_DOWNLOADED = '' # number of episodes you already downloaded (maybe saved elsewhere)
 CA_FILE = '' # on windows you might need to use the cert file
 
 SAVE_DIRECTORY = 'RubyTapas'

--- a/constants.rb.example
+++ b/constants.rb.example
@@ -1,5 +1,7 @@
 USER_NAME = ''
 USER_PASSWORD = ''
 
+CA_FILE = '' # on windows you might need to use the cert file
+
 SAVE_DIRECTORY = 'RubyTapas'
 TAPAS_BASE_URL = 'https://www.rubytapas.com'

--- a/lib/classes/episode_link.rb
+++ b/lib/classes/episode_link.rb
@@ -6,12 +6,17 @@ require_relative '../pages/episode_page'
 class EpisodeLink < Struct.new(:href)
   def call
     return unless is_episode?
+    return if is_downloaded?
 
     download_episode
   end
 
   def download_episode
     EpisodePage.new(link_obj).download_episode
+  end
+
+  def is_downloaded?
+    @episode_regex[:episode_number].to_i <= ALREADY_DOWNLOADED.to_i
   end
 
   def is_episode?

--- a/lib/classes/logged_browser.rb
+++ b/lib/classes/logged_browser.rb
@@ -8,6 +8,6 @@ class LoggedBrowser
   end
 
   def browser
-    @browser ||= Watir::Browser.new
+    @browser ||= Watir::Browser.new(:chrome)
   end
 end

--- a/lib/extractors/save_file.rb
+++ b/lib/extractors/save_file.rb
@@ -3,7 +3,7 @@ class SaveFile < Struct.new(:browser, :episode_directory)
   def call
     create_save_directory
 
-    File.open(file_path, 'w') do |f|
+    File.open(file_path, 'wb') do |f|
       f.write data
     end
   end

--- a/lib/extractors/save_video.rb
+++ b/lib/extractors/save_video.rb
@@ -4,7 +4,7 @@ class SaveVideo < SaveFile
   def call
     create_save_directory
 
-    File.open(file_path, 'w') do |f|
+    File.open(file_path, 'wb') do |f|
       f << open(data).read
     end
   end

--- a/ruby-tapas-downloader.rb
+++ b/ruby-tapas-downloader.rb
@@ -9,6 +9,7 @@ require_relative './lib/extractors/save_content_html'
 require_relative './lib/extractors/save_page_source'
 require_relative './lib/extractors/save_video'
 require 'pry'
+require 'net/https'
 
 BROWSER = LoggedBrowser.new.call
 
@@ -45,6 +46,20 @@ end
 
 def log_status_update(update)
   puts "--- #{update} ---"
+end
+
+unless (CA_FILE.nil? || CA_FILE.empty?) then
+  module Net
+    class HTTP
+      alias_method :original_use_ssl=, :use_ssl=
+
+      def use_ssl=(flag)
+        self.ca_file = CA_FILE
+        self.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        self.original_use_ssl = flag
+      end
+    end
+  end
 end
 
 RubyTapasDownloader.new.call


### PR DESCRIPTION
- Windows SSH errors (certificates not visible)
- Windows Firefox issue (watir on FF, overlaying elements not clickable)
- Windows Video issue (needs to be saved in binary)
- Feature (when files are on slow network drive or go to thumbdrive, where you won't have the whole Ruby Tapas library, its better to have chance to specify the number from which you can start the download)